### PR TITLE
v1.011

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,7 @@ node_js:
 install:
   - npm install
 script:
+  - npm run build
   - npm run coverage
   - cat coverage/lcov.info | coveralls
+  - npm run test

--- a/buidler.config.js
+++ b/buidler.config.js
@@ -78,7 +78,7 @@ module.exports = {
     deployments: path.join(__dirname, "deployments")
   },
   solc: {
-    version: "0.6.8",
+    version: "0.6.12",
     optimizer: {
       enabled: true,
       runs: 200

--- a/contracts/CodeHashes.sol
+++ b/contracts/CodeHashes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.6.0;
+pragma solidity =0.6.12;
 
 
 /**
@@ -8,7 +8,7 @@ pragma solidity ^0.6.0;
  * values when they import the salt library.
  */
 library CodeHashes {
-  bytes32 internal constant ONE_TO_ONE_CODEHASH = 0xfeddfba61044051906dd1a07bb1531102730bc2ac6f0a420b8126c5ba6c10cf7;
-  bytes32 internal constant MANY_TO_ONE_CODEHASH = 0x2f98a80b374682a6ae977e416d9b4a15fc5c083cd80e6b70d2542ebeca2c2918;
-  bytes32 internal constant IMPLEMENTATION_HOLDER_CODEHASH = 0xa558acad70fc124d64322222d54e3d36df3cfa2816409762b436d03a15018df3;
+  bytes32 internal constant ONE_TO_ONE_CODEHASH = 0x980843d7182154db438d410718903ca4c4116c8f430643d49eb654ed1776ed41;
+  bytes32 internal constant MANY_TO_ONE_CODEHASH = 0xb4e09618634e1d4fad81090ab8fb8259b749a9202aa02d7720af654b9b4ca17b;
+  bytes32 internal constant IMPLEMENTATION_HOLDER_CODEHASH = 0xfc7aed17e5c5d36a15e443235cb9c59bae4a013202cde6ab3e657fa1176d7f3e;
 }

--- a/contracts/CodeHashes.sol
+++ b/contracts/CodeHashes.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.6.0;
+
+import "./ManyToOneImplementationHolder.sol";
+import { DelegateCallProxyManyToOne } from "./DelegateCallProxyManyToOne.sol";
+import { DelegateCallProxyOneToOne } from "./DelegateCallProxyOneToOne.sol";
+
+
+/**
+ * @dev Because we use the code hashes of the proxy contracts for proxy address
+ * derivation, it is important that other packages have access to the correct
+ * values when they import the salt library.
+ */
+library CodeHashes {
+  bytes32 internal constant ONE_TO_ONE_CODEHASH = 0xfeddfba61044051906dd1a07bb1531102730bc2ac6f0a420b8126c5ba6c10cf7;
+  bytes32 internal constant MANY_TO_ONE_CODEHASH = 0x2f98a80b374682a6ae977e416d9b4a15fc5c083cd80e6b70d2542ebeca2c2918;
+  bytes32 internal constant IMPLEMENTATION_HOLDER_CODEHASH = 0xa558acad70fc124d64322222d54e3d36df3cfa2816409762b436d03a15018df3;
+}

--- a/contracts/CodeHashes.sol
+++ b/contracts/CodeHashes.sol
@@ -1,10 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.6.0;
 
-import "./ManyToOneImplementationHolder.sol";
-import { DelegateCallProxyManyToOne } from "./DelegateCallProxyManyToOne.sol";
-import { DelegateCallProxyOneToOne } from "./DelegateCallProxyOneToOne.sol";
-
 
 /**
  * @dev Because we use the code hashes of the proxy contracts for proxy address

--- a/contracts/DelegateCallProxyManager.sol
+++ b/contracts/DelegateCallProxyManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.6.0;
+pragma solidity =0.6.12;
 
 /* ==========  External Libraries  ========== */
 import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";

--- a/contracts/DelegateCallProxyManager.sol
+++ b/contracts/DelegateCallProxyManager.sol
@@ -13,6 +13,7 @@ import { DelegateCallProxyOneToOne } from "./DelegateCallProxyOneToOne.sol";
 
 /* ==========  Internal Libraries  ========== */
 import { SaltyLib as Salty } from "./SaltyLib.sol";
+import { CodeHashes } from "./CodeHashes.sol";
 
 /* ==========  Inheritance  ========== */
 import "./interfaces/IDelegateCallProxyManager.sol";
@@ -57,17 +58,6 @@ import "./interfaces/IDelegateCallProxyManager.sol";
  * it becomes impossible to upgrade.
  */
 contract DelegateCallProxyManager is Ownable, IDelegateCallProxyManager {
-/* ==========  Constants  ========== */
-
-  bytes32 internal constant ONE_TO_ONE_CODEHASH
-  = keccak256(type(DelegateCallProxyOneToOne).creationCode);
-
-  bytes32 internal constant MANY_TO_ONE_CODEHASH
-  = keccak256(type(DelegateCallProxyManyToOne).creationCode);
-
-  bytes32 internal constant IMPLEMENTATION_HOLDER_CODEHASH
-  = keccak256(type(ManyToOneImplementationHolder).creationCode);
-
 /* ==========  Events  ========== */
 
   event DeploymentApprovalGranted(address deployer);
@@ -444,7 +434,7 @@ contract DelegateCallProxyManager is Ownable, IDelegateCallProxyManager {
     returns (address)
   {
     bytes32 salt = Salty.deriveOneToOneSalt(originator, suppliedSalt);
-    return Create2.computeAddress(salt, ONE_TO_ONE_CODEHASH);
+    return Create2.computeAddress(salt, CodeHashes.ONE_TO_ONE_CODEHASH);
   }
 
   /**
@@ -472,7 +462,7 @@ contract DelegateCallProxyManager is Ownable, IDelegateCallProxyManager {
       implementationID,
       suppliedSalt
     );
-    return Create2.computeAddress(salt, MANY_TO_ONE_CODEHASH);
+    return Create2.computeAddress(salt, CodeHashes.MANY_TO_ONE_CODEHASH);
   }
 
   /**
@@ -489,7 +479,7 @@ contract DelegateCallProxyManager is Ownable, IDelegateCallProxyManager {
   {
     return Create2.computeAddress(
       implementationID,
-      IMPLEMENTATION_HOLDER_CODEHASH
+      CodeHashes.IMPLEMENTATION_HOLDER_CODEHASH
     );
   }
 

--- a/contracts/DelegateCallProxyManyToOne.sol
+++ b/contracts/DelegateCallProxyManyToOne.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.6.0;
+pragma solidity =0.6.12;
 
 import { Proxy } from "@openzeppelin/contracts/proxy/Proxy.sol";
 

--- a/contracts/DelegateCallProxyOneToOne.sol
+++ b/contracts/DelegateCallProxyOneToOne.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.6.0;
+pragma solidity =0.6.12;
 
 import { Proxy } from "@openzeppelin/contracts/proxy/Proxy.sol";
 

--- a/contracts/ManyToOneImplementationHolder.sol
+++ b/contracts/ManyToOneImplementationHolder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.6.0;
+pragma solidity =0.6.12;
 
 
 /**

--- a/contracts/SaltyLib.sol
+++ b/contracts/SaltyLib.sol
@@ -5,9 +5,7 @@ pragma solidity ^0.6.0;
 import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
 /* ---  Proxy Contracts  --- */
-import "./ManyToOneImplementationHolder.sol";
-import { DelegateCallProxyManyToOne } from "./DelegateCallProxyManyToOne.sol";
-import { DelegateCallProxyOneToOne } from "./DelegateCallProxyOneToOne.sol";
+import { CodeHashes } from "./CodeHashes.sol";
 
 
 /**
@@ -20,19 +18,6 @@ import { DelegateCallProxyOneToOne } from "./DelegateCallProxyOneToOne.sol";
  * contract and the implementation ID used (for many-to-one proxies only).
  */
 library SaltyLib {
-/* ---  Constants  --- */
-  bytes32 internal constant ONE_TO_ONE_CODEHASH = keccak256(
-    type(DelegateCallProxyOneToOne).creationCode
-  );
-
-  bytes32 internal constant MANY_TO_ONE_CODEHASH = keccak256(
-    type(DelegateCallProxyManyToOne).creationCode
-  );
-
-  bytes32 internal constant IMPLEMENTATION_HOLDER_CODEHASH = keccak256(
-    type(ManyToOneImplementationHolder).creationCode
-  );
-
 /* ---  Salt Derivation  --- */
 
   /**
@@ -104,7 +89,7 @@ library SaltyLib {
     returns (address)
   {
     bytes32 salt = deriveOneToOneSalt(originator, suppliedSalt);
-    return Create2.computeAddress(salt, ONE_TO_ONE_CODEHASH, deployer);
+    return Create2.computeAddress(salt, CodeHashes.ONE_TO_ONE_CODEHASH, deployer);
   }
 
   /**
@@ -132,7 +117,7 @@ library SaltyLib {
       implementationID,
       suppliedSalt
     );
-    return Create2.computeAddress(salt, MANY_TO_ONE_CODEHASH, deployer);
+    return Create2.computeAddress(salt, CodeHashes.MANY_TO_ONE_CODEHASH, deployer);
   }
 
   /**
@@ -152,7 +137,7 @@ library SaltyLib {
   {
     return Create2.computeAddress(
       implementationID,
-      IMPLEMENTATION_HOLDER_CODEHASH,
+      CodeHashes.IMPLEMENTATION_HOLDER_CODEHASH,
       deployer
     );
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,54 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "@ethersproject/abi": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.2.tgz",
@@ -2169,6 +2217,12 @@
       "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==",
       "dev": true
     },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
     "@types/pbkdf2": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
@@ -3208,6 +3262,12 @@
         }
       }
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -3493,6 +3553,12 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
+    "compare-versions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -3632,6 +3698,19 @@
       "requires": {
         "object-assign": "^4",
         "vary": "^1"
+      }
+    },
+    "cosmiconfig": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+      "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+      "dev": true,
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
       }
     },
     "coveralls": {
@@ -4336,6 +4415,15 @@
       "dev": true,
       "requires": {
         "prr": "~1.0.1"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -5429,6 +5517,15 @@
       "dev": true,
       "requires": {
         "locate-path": "^2.0.0"
+      }
+    },
+    "find-versions": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.2.0.tgz",
+      "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
+      "dev": true,
+      "requires": {
+        "semver-regex": "^2.0.0"
       }
     },
     "flat": {
@@ -6853,6 +6950,24 @@
         "debug": "4"
       }
     },
+    "husky": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.0.tgz",
+      "integrity": "sha512-tTMeLCLqSBqnflBZnlVDhpaIMucSGaYyX6855jM4AguGeWCeSzNdb1mfyWduTZ3pe3SJVvVWGL0jO1iKZVPfTA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "ci-info": "^2.0.0",
+        "compare-versions": "^3.6.0",
+        "cosmiconfig": "^7.0.0",
+        "find-versions": "^3.2.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^4.2.0",
+        "please-upgrade-node": "^3.2.0",
+        "slash": "^3.0.0",
+        "which-pm-runs": "^1.0.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -6888,6 +7003,24 @@
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
       "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
       "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
+      }
     },
     "inflight": {
       "version": "1.0.6",
@@ -6956,6 +7089,12 @@
       "requires": {
         "kind-of": "^3.0.2"
       }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -7237,6 +7376,12 @@
       "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
       "dev": true
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -7257,6 +7402,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "json-schema": {
@@ -7643,6 +7794,12 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
     },
     "locate-path": {
       "version": "2.0.0",
@@ -8654,6 +8811,12 @@
         "wrappy": "1"
       }
     },
+    "opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "dev": true
+    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -8734,6 +8897,15 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-asn1": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
@@ -8795,6 +8967,18 @@
       "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA==",
       "dev": true
     },
+    "parse-json": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+      "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -8841,6 +9025,12 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
     "pathval": {
@@ -8905,6 +9095,75 @@
       "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
+      }
+    },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
       }
     },
     "posix-character-classes": {
@@ -9580,6 +9839,18 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
+    "semver-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
+      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
       "dev": true
     },
     "send": {
@@ -12121,6 +12392,12 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+      "dev": true
+    },
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
@@ -12277,6 +12554,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
       "dev": true
     },
     "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexed-finance/proxies",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "deployments/mainnet"
   ],
   "scripts": {
+    "prebuild": "buidler compile && node ./scripts/write-code-hashes.js",
     "build": "buidler compile",
+    "postbuild": "echo Built sol files with updated CodeHashes",
     "coverage": "buidler coverage --network coverage --solcoverjs ./.solcover.js",
     "deploy:rinkeby": "buidler --network rinkeby deploy",
     "test": "buidler test ./test/test-proxy.spec.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexed-finance/proxies",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Solidity delegatecall proxy contracts.",
   "repository": {
     "url": "https://github.com/indexed-finance/proxies"

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
     "prebuild": "buidler compile && node ./scripts/write-code-hashes.js",
     "build": "buidler compile",
     "postbuild": "echo Built sol files with updated CodeHashes",
+    "precoverage": "cross-env IS_COVERAGE=true node ./scripts/write-code-hashes.js",
     "coverage": "buidler coverage --network coverage --solcoverjs ./.solcover.js",
+    "postcoverage": "node ./scripts/write-code-hashes.js",
     "deploy:rinkeby": "buidler --network rinkeby deploy",
-    "test": "buidler test ./test/test-proxy.spec.js",
+    "test": "buidler test",
     "node": "npx buidler node --port 8546 --verbose",
     "benchmark": "cross-env REPORT_GAS=true npx buidler test ./test/benchmark.spec.js"
   },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,12 @@
     "node": "npx buidler node --port 8546 --verbose",
     "benchmark": "cross-env REPORT_GAS=true npx buidler test ./test/benchmark.spec.js"
   },
+  "husky": {
+    "hooks": {
+      "pre-push": "npm run build && npm run coverage && npm test",
+      "...": "..."
+    }
+  },
   "keywords": [],
   "author": "Dillon Kellar",
   "license": "GPL-3.0-or-later",
@@ -42,6 +48,7 @@
     "dotenv": "^8.2.0",
     "ethereumjs-wallet": "^0.6.5",
     "ethers": "^5.0.8",
+    "husky": "^4.3.0",
     "moment": "^2.29.1",
     "prettier": "^2.0.5",
     "prettier-plugin-solidity": "^1.0.0-alpha.55",

--- a/scripts/write-code-hashes.js
+++ b/scripts/write-code-hashes.js
@@ -12,10 +12,6 @@ const IMPLEMENTATION_HOLDER_CODEHASH = soliditySha3(toBytecode('ManyToOneImpleme
 const CodeHashesLibrary = `// SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.6.0;
 
-import "./ManyToOneImplementationHolder.sol";
-import { DelegateCallProxyManyToOne } from "./DelegateCallProxyManyToOne.sol";
-import { DelegateCallProxyOneToOne } from "./DelegateCallProxyOneToOne.sol";
-
 
 /**
  * @dev Because we use the code hashes of the proxy contracts for proxy address

--- a/scripts/write-code-hashes.js
+++ b/scripts/write-code-hashes.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const { soliditySha3 } = require('web3-utils');
+
+const artifactsDir = path.join(__dirname, '..', 'artifacts');
+const toBytecode = (file) => require(path.join(artifactsDir, file)).bytecode;
+
+const ONE_TO_ONE_CODEHASH = soliditySha3(toBytecode('DelegateCallProxyOneToOne.json'));
+const MANY_TO_ONE_CODEHASH = soliditySha3(toBytecode('DelegateCallProxyManyToOne.json'));
+const IMPLEMENTATION_HOLDER_CODEHASH = soliditySha3(toBytecode('ManyToOneImplementationHolder.json'));
+
+const CodeHashesLibrary = `// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.6.0;
+
+import "./ManyToOneImplementationHolder.sol";
+import { DelegateCallProxyManyToOne } from "./DelegateCallProxyManyToOne.sol";
+import { DelegateCallProxyOneToOne } from "./DelegateCallProxyOneToOne.sol";
+
+
+/**
+ * @dev Because we use the code hashes of the proxy contracts for proxy address
+ * derivation, it is important that other packages have access to the correct
+ * values when they import the salt library.
+ */
+library CodeHashes {
+  bytes32 internal constant ONE_TO_ONE_CODEHASH = ${ONE_TO_ONE_CODEHASH};
+  bytes32 internal constant MANY_TO_ONE_CODEHASH = ${MANY_TO_ONE_CODEHASH};
+  bytes32 internal constant IMPLEMENTATION_HOLDER_CODEHASH = ${IMPLEMENTATION_HOLDER_CODEHASH};
+}`;
+
+const libraryPath = path.join(__dirname, '..', 'contracts', 'CodeHashes.sol');
+fs.writeFileSync(libraryPath, CodeHashesLibrary, 'utf8');


### PR DESCRIPTION
# v1.011

## Updated CI
* Added build and test execution to .travis.yml
* Added husky dependency with pre-push requirements to build and test the repo.

## Fixed errors with external use | Resolves #1

Because SaltyLib.sol uses `keccak256(type(contract).creationCode)` as a constant for computing proxy addresses, if it is imported in another project it can result in errors where the library cannot compute the correct addresses, even if the same version of Solidity is used to compile it. This seems to be related to the swarm hash produced in the proxy contracts when they are built, but I'm not 100% sure. This can be fixed by hard-coding the constants in SaltyLib.

### Solution
* Replaced `pragma solidity ^0.6.0` with `pragma solidity =0.6.12` in proxy contracts and proxy manager.
* Set solidity version in buidler.config.js to 0.6.12
* Added a library `CodeHashes.sol` with the hard-coded initcode hashes of the proxy contracts.
* Replaced compile-time calculation of the code hashes in SaltyLib and DelegateCallProxyManager with references to `CodeHashes`
* Added a `prebuild` script in the repo to update `CodeHashes` when the `build` script is run (in case the proxy contracts are ever changed)
* Added `precoverage` and `postcoverage` scripts to replace the hard-coded codehashes with compile-time constants to keep coverage from breaking, as it modifies the bytecode.